### PR TITLE
feature/missingness

### DIFF
--- a/python/environment.yml
+++ b/python/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python=3.7
+  - python=3.10
   - seaborn
   - matplotlib
   - pandas

--- a/python/unravel/lib/dirs.py
+++ b/python/unravel/lib/dirs.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Dict
+from typing import List, Dict, Tuple
 
 # TODO
 # - Sanity checks and useful warnings
@@ -50,7 +50,7 @@ class TapestrySampleOutputDir:
 		self.compare_heuristic_csv = f"{self.tapestry_dir}/compare.heuristic.csv"
 		self.compare_evidence_csv = f"{self.tapestry_dir}/compare.evidence.csv"
 
-	def _get_coi_info(self) -> (List[str], List[int]):
+	def _get_coi_info(self) -> Tuple[List[str], List[int]]:
 		""" 
 		Get all COI directories, 'K[0-9]{1}'
 		

--- a/python/unravel/lib/dirs.py
+++ b/python/unravel/lib/dirs.py
@@ -55,13 +55,14 @@ class TapestrySampleOutputDir:
 		Get all COI directories, 'K[0-9]{1}'
 		
 		"""
-
-		coi_dirs = [
-			f"{self.tapestry_dir}/{d}"
-			for d in os.listdir(self.tapestry_dir)
-			if d.startswith("K") and os.path.isdir(f"{self.tapestry_dir}/{d}")
-		]
-		cois = [int(coi_dir[-1]) for coi_dir in coi_dirs]
+		Ks = range(1, 10) # maximum to check is 9
+		coi_dirs = []
+		cois =[]
+		for K in Ks:
+			coi_dir = f"{self.tapestry_dir}/K{K:d}"
+			if os.path.isdir(coi_dir):
+				coi_dirs.append(coi_dir)
+				cois.append(K)
 		
 		return (coi_dirs, cois)
 	

--- a/python/unravel/lib/plot_ibd.py
+++ b/python/unravel/lib/plot_ibd.py
@@ -281,7 +281,6 @@ class CombinedPlotter:
         for i, axis_item in enumerate(axes_order):
             
             # Plot
-            print(f"  {axis_item.name}...")
             ax = plt.subplot(gs[l:(l+axis_item.rows+1)])
             axis_item.plot_func(ax)
             

--- a/python/unravel/lib/plot_ibd.py
+++ b/python/unravel/lib/plot_ibd.py
@@ -298,5 +298,5 @@ class CombinedPlotter:
 
         # Optionally write
         if output_path is not None:
-            fig.savefig(output_path, bbox_inches="tight", pad_inches=0.5)
+            fig.savefig(output_path, bbox_inches="tight", pad_inches=0.5, dpi=300)
             plt.close(fig)

--- a/python/unravel/lib/plot_ibd.py
+++ b/python/unravel/lib/plot_ibd.py
@@ -9,14 +9,14 @@ from matplotlib.patches import Rectangle
 from unravel.lib.ibd import get_ibd_segments
 
 class WSAFPlotter:
-    def __init__(self, wsaf_df, chrom_info):
+    def __init__(self, wsaf_df: pd.DataFrame, chrom_info):
         """
         Create a plot of WSAF along the genome
         
         """
         
         # Storage
-        self.wsaf_df = wsaf_df
+        self.wsaf_df = self._calc_wsafs_for_dataframe(wsaf_df)
         self.chrom_info = chrom_info
         
         # Compute adjusted positions
@@ -24,6 +24,24 @@ class WSAFPlotter:
             chroms=wsaf_df["chrom"],
             pos=wsaf_df["pos"]
         )
+
+    def _calc_wsafs_for_dataframe(self, wsaf_df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Process the WSAF dataframe to calculate WSAF, handling missing data.
+        """
+
+        assert "refs" in wsaf_df.columns, "Missing 'refs' column from WSAF dataframe."
+        assert "alts" in wsaf_df.columns, "Missing 'alts' column from WSAF dataframe."
+        
+        def calc_wsaf(row: pd.Series, epsilon: float = 0.001):
+            if row['refs'] == -1 or row['alts'] == -1:
+                return None
+            return row['alts'] / (row['refs'] + row['alts'] + epsilon)
+
+        wsaf_df["wsafs"] = wsaf_df.apply(calc_wsaf, axis=1)
+
+        return wsaf_df
+
         
         
     def plot(self, ax, title=None, add_grid=True):

--- a/python/unravel/lib/plot_mcmc.py
+++ b/python/unravel/lib/plot_mcmc.py
@@ -218,7 +218,8 @@ class ProportionsTracePlotter:
             fig.savefig(
                 output_path,
                 bbox_inches="tight",
-                pad_inches=0.5
+                pad_inches=0.5,
+                dpi=300
             )
             plt.close(fig)
 
@@ -407,7 +408,8 @@ class DiagnosticsTracePlotter:
             fig.savefig(
                 output_path,
                 bbox_inches="tight",
-                pad_inches=0.5
+                pad_inches=0.5,
+                dpi=300
             )
             plt.close(fig)
 

--- a/python/unravel/sample/main.py
+++ b/python/unravel/sample/main.py
@@ -16,11 +16,14 @@ def sample(sample_dir: str) -> None:
 
     # Define tapestry directories
     tapestry_dirs = TapestrySampleOutputDir(sample_dir)
+    print(f"Processing tapestry data from: {tapestry_dirs.tapestry_dir}")
 
     # Iterate over COIs and plot
     for coi, coi_dirs in tapestry_dirs.coi.items():
         png_temp = f"{coi_dirs.coi_dir}/plot.{'{name}'}.png"
-        print(f"Plotting for COI={coi}...")
+        if coi == 1:
+            continue
+        print(f"  Plotting COI={coi}...")
 
         # MCMC Plots ---------------------------------------------
         prop_plotter = ProportionsTracePlotter(
@@ -64,4 +67,5 @@ def sample(sample_dir: str) -> None:
         combined_plotter.plot(
             output_path=png_temp.format(name="fit.ibd_segments")
         )
+    print("Done.")
 

--- a/src/betabin.cpp
+++ b/src/betabin.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include "typedefs.hpp"
 #include "betabin.hpp"
+#include "constants.hpp"
 using namespace std;
 
 
@@ -12,9 +13,10 @@ BetabinomialArray::BetabinomialArray(const Parameters& params, const VCFData& da
     : params(params),
     data(data),
     as_loglikelihood(true),
-    lookup_matrix(MatrixXd::Constant(data.n_sites, params.n_pi_bins, -1.0))
+    lookup_matrix(MatrixXd::Constant(data.n_sites, params.n_pi_bins, DEFAULT_FLOAT))
 {
     calc_lookup_matrix(as_loglikelihood);
+    check_valid();
 };
 
 
@@ -22,9 +24,10 @@ BetabinomialArray::BetabinomialArray(const Parameters& params, const VCFData& da
     : params(params),
     data(data),
     as_loglikelihood(as_loglikelihood),
-    lookup_matrix(MatrixXd::Constant(data.n_sites, params.n_pi_bins, -1.0))
+    lookup_matrix(MatrixXd::Constant(data.n_sites, params.n_pi_bins, DEFAULT_FLOAT))
 {
     calc_lookup_matrix(as_loglikelihood);
+    check_valid();
 };
 
 
@@ -42,7 +45,19 @@ void BetabinomialArray::calc_lookup_matrix(bool as_loglikelihood)
     for (int i = 0; i < data.n_sites; ++i) {
 
         // Check if you have already computed for this (REF, ALT) pair
-        pair<int, int> ra_pair(data.refs(i), data.alts(i));
+        pair<int, int> ra_pair{data.refs(i), data.alts(i)};
+        
+        // Handle case of missing data
+        if (ra_pair == missing_pair) {
+            if (as_loglikelihood) {
+                lookup_matrix.row(i).setZero();
+            } else {
+                lookup_matrix.row(i).setOnes();
+            }
+            continue;
+        }
+
+        // Check if already computed
         auto found = ra_pair_map.find(ra_pair);
         if (found != ra_pair_map.end()) {
             lookup_matrix.row(i) = lookup_matrix.row(found->second); // TODO: is this best?
@@ -51,6 +66,7 @@ void BetabinomialArray::calc_lookup_matrix(bool as_loglikelihood)
 
         // If not, compute probabilities
         // TODO: is this math construction best?
+        // TODO: Here is where we are computing the likelihood;
         double tmp0 = lgamma(data.alts(i) + data.refs(i) + 1) - lgamma(data.alts(i) + 1) - lgamma(data.refs(i) + 1);
         double tmp1 = lgamma(params.v) - lgamma(data.alts(i) + data.refs(i) + params.v);
 
@@ -67,6 +83,13 @@ void BetabinomialArray::calc_lookup_matrix(bool as_loglikelihood)
             
             ra_pair_map[ra_pair] = i;
         }
+    }
+}
+
+void BetabinomialArray::check_valid() const
+{
+    if ((lookup_matrix.array() == DEFAULT_FLOAT).any()) {
+        throw std::invalid_argument("Failed to completely initialise Beta-binomial lookup.");
     }
 }
 

--- a/src/betabin.hpp
+++ b/src/betabin.hpp
@@ -5,38 +5,11 @@
 #include <utility>
 #include <unordered_map>
 #include <vector>
+#include "constants.hpp"
 #include "data.hpp"
 #include "parameters.hpp"
 #include "typedefs.hpp"
 using namespace std;
-
-
-// Create a class that encapsulates a betabinomial array
-// - during development, we may produce different types of arrays
-// - we want them all to behave similiarly
-// - could even profile lookup vs. no lookup
-// - what would API be?
-
-// betabin.compute_emission(pi_val);
-// - But that is different from overloading the () operator
-
-// - We have Factories that produce these different arrays
-
-
-
-// Create a class that is a betabinomial array
-// - I want it to behave close to a normal Eigen array
-// - But it takes float values
-
-
-/*
-* Create a `Betabinomial` array
-*
-*
-*/
-// class BetabinomialArrayFactory
-// {};
-
 
 
 class BetabinomialArray
@@ -60,9 +33,9 @@ private:
     const VCFData& data;
 
     MatrixXd lookup_matrix;
-
-
+    const pair<int, int> missing_pair{MISSING_AD_VALUE, MISSING_AD_VALUE};
     void calc_lookup_matrix(bool as_loglikelihood);
+    void check_valid() const; // Check that all values have been initialised.
 
 public:
 

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -14,3 +14,9 @@ const int BELL_NUMBERS[11] = {
         21147,
         115975
 };
+
+// Value assigned if allelic depth (AD) data is missing
+const int MISSING_AD_VALUE = -1;
+
+const int DEFAULT_INT = -9999;
+const float DEFAULT_FLOAT = -9999.0;

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -1,8 +1,10 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <stdlib.h>
 #include "vcf.hpp"
 #include "data.hpp"
+#include "constants.hpp"
 using namespace std;
 
 
@@ -10,13 +12,13 @@ VCFData::VCFData(const string& vcf_path, const string& sample_name)
     : vcf_path(vcf_path),
     sample_name(sample_name),
     n_sites(count_sites_in_vcf(vcf_path)),
+    n_sites_missing(0),
     chrom_names(n_sites),
-    chroms(ArrayXi::Constant(n_sites, -1)),
-    pos(ArrayXi::Constant(n_sites, -1)),
-    refs(ArrayXi::Constant(n_sites, -1)),
-    alts(ArrayXi::Constant(n_sites, -1)),
-    wsafs(ArrayXd::Constant(n_sites, -1.0)),
-    plafs(ArrayXd::Constant(n_sites, -1.0))
+    chroms(ArrayXi::Constant(n_sites, DEFAULT_INT)),
+    pos(ArrayXi::Constant(n_sites, DEFAULT_INT)),
+    refs(ArrayXi::Constant(n_sites, DEFAULT_INT)),
+    alts(ArrayXi::Constant(n_sites, DEFAULT_INT)),
+    plafs(ArrayXd::Constant(n_sites, DEFAULT_FLOAT))
 {
     // Prepare pointers to file, header and record
     htsFile* fp;
@@ -48,12 +50,18 @@ VCFData::VCFData(const string& vcf_path, const string& sample_name)
         int sz = 0;
         int* vals = NULL;
         if (bcf_get_format_int32(hdr, rec, "AD", &vals, &sz) > 0) {
-            if (sz != 2) {
-                throw std::invalid_argument("Error: all sites must be bi-allelic.");
+            
+            if (sz == 1) { // could also be monoallelic, in which case treat as missing
+                n_sites_missing += 1;
+                refs(site_ix) = MISSING_AD_VALUE;
+                alts(site_ix) = MISSING_AD_VALUE;
+            } else if (sz != 2) {
+                throw std::invalid_argument("Error parsing VCF: all sites must be bi-allelic.");
+            } else {
+                refs(site_ix) = vals[0];
+                alts(site_ix) = vals[1];
             }
-            refs(site_ix) = vals[0];
-            alts(site_ix) = vals[1];
-            wsafs(site_ix) = vals[1] / (vals[0] + vals[1] + epsilon);
+
         } else {
             throw std::invalid_argument("Error: failed to read AD for a site.");
         }
@@ -67,14 +75,31 @@ VCFData::VCFData(const string& vcf_path, const string& sample_name)
     bcf_destroy(rec);
     vcf_close(fp);
 
-    // Calculate PLAFs
     plafs = calc_plafs_from_vcf(vcf_path);
-
-    // TODO:
-    // - Check all the output arrays are sensible (i.e. in correct ranges)
     genome_length = calc_genome_length();
+
+    // Validity check
+    check_valid();
 }
 
+void VCFData::check_valid() const
+{
+    if ((chroms == DEFAULT_INT).any()) {
+        std::invalid_argument("Error parsing VCF!");
+    }
+    if ((pos == DEFAULT_INT).any()) {
+        std::invalid_argument("Error parsing VCF!");
+    }
+    if ((refs == DEFAULT_INT).any()) {
+        std::invalid_argument("Error parsing VCF!");
+    }
+    if ((alts == DEFAULT_INT).any()) {
+        std::invalid_argument("Error parsing VCF!");
+    }
+    if ((plafs == DEFAULT_FLOAT).any()) {
+        std::invalid_argument("Error parsing VCF!");
+    }
+}
 
 int VCFData::calc_genome_length()
 {
@@ -111,16 +136,17 @@ void VCFData::print() const
 {
     cout << "Loaded VCF data" << endl;
     cout << "  VCF path: " << vcf_path << endl;
-    cout << "    No. Sites: " << n_sites << endl;
-    cout << "    No. Samples: " << n_samples << endl;
+    cout << "    No. sites: " << n_sites << endl;
+    cout << "    No. samples: " << n_samples << endl;
     cout << "  Target sample: " << sample_name << endl;
+    cout << "    No. sites with missing data for target sample: " << n_sites_missing << endl;
 
     // TODO: should make a macro or inline function for these...
+    cout << "  Site data:" << endl;
     cout << "    Chromosomes: " << chrom_names[0] << " ... " << chrom_names[n_sites - 1] << endl;
     cout << "    Positions: " << pos(0) << " ... " << pos(n_sites - 1) << endl;
     cout << "    REFs: " << refs(0) << " ... " << refs(n_sites - 1) << endl;
     cout << "    ALTs: " << alts(0) << " ... " << alts(n_sites - 1) << endl;
-    cout << "    WSAFs: " << wsafs(0) << " ... " << wsafs(n_sites - 1) << endl;
     cout << "    PLAFs: " << plafs(0) << " ... " << plafs(n_sites - 1) << endl;
 }
 

--- a/src/data.hpp
+++ b/src/data.hpp
@@ -24,7 +24,6 @@ using Eigen::ArrayXd;
 
 
 
-
 /*
 * Encapsulate VCF data from `vcf_path` for a target sample, 
 * given by `sample_name`
@@ -38,15 +37,15 @@ using Eigen::ArrayXd;
 class VCFData
 {
 private:
-    double epsilon = 0.001;             // Adjustment to compute WSAF if depth zero
-    const string& vcf_path;             // path to VCF file
-    const string& sample_name;          // target sample name
+    const string& vcf_path;             // Path to VCF
+    const string& sample_name;          // Target sample name
 
     int calc_genome_length();
     
 public:
     int n_samples;
     int n_sites;
+    int n_sites_missing;
     int genome_length;                  // Length of genome in basepairs (bp)
 
     vector<string> chrom_names;
@@ -54,11 +53,11 @@ public:
     ArrayXi pos;
     ArrayXi refs;                       // Read counts of REF allele
     ArrayXi alts;                       // Read counts of ALT allele
-    ArrayXd wsafs;                      // Within-sample ALT freq. [ALT/(REF+ALT+epsilon)]
-    ArrayXd plafs;                      // Population-level allele freq.
+    ArrayXd plafs;                      // Population-level allele frequencies
 
     VCFData(const string& vcf_path, const string& sample_name);
 
+    void check_valid() const;
     void print() const;
 };
 

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -35,7 +35,7 @@ void write_data_with_annotation(
     }
 
     // Write column names
-    csv_file << "chrom,pos,refs,alts,wsafs,plafs";
+    csv_file << "chrom,pos,refs,alts,plafs";
     for (const string& col_name : annotation_columns) {
         csv_file << "," << col_name;
     }
@@ -58,7 +58,7 @@ void write_data_with_annotation(
         csv_file << data.pos(i) << ",";
         csv_file << data.refs(i) << ",";
         csv_file << data.alts(i) << ",";
-        csv_file << data.wsafs(i) << ",";
+        //csv_file << data.wsafs(i) << ",";
         csv_file << data.plafs(i) << ",";
         // TODO:
         // Need to check that the row length is non-zero;

--- a/src/vcf.cpp
+++ b/src/vcf.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include "htslib/vcf.h"
@@ -5,13 +6,6 @@
 #include "vcf.hpp"
 using Eigen::ArrayXd;
 using namespace std;
-
-// TODO:
-// `count_sites_in_vcf` should handle missing sites
-// For every site, we check if everything is present
-// I also need to make the PLAF calculation handle missingness
-// Best might be to return a struct:
-// - Could hold the total number of sites as well as those non-missing
 
 
 int count_sites_in_vcf(const string& vcf_path)
@@ -60,27 +54,45 @@ ArrayXd calc_plafs_from_vcf(const string& vcf_path, double epsilon)
     // Prepare arrays
     int n_samples = bcf_hdr_nsamples(hdr);
     int n_sites = count_sites_in_vcf(vcf_path);
-    ArrayXd total_depth = ArrayXd::Constant(n_sites, -9999); // TODO: Could be used as default value for missing data.
-    ArrayXd total_alts = ArrayXd::Constant(n_sites, -9999);
+    ArrayXd total_depth = ArrayXd::Constant(n_sites, 0);
+    ArrayXd total_alts = ArrayXd::Constant(n_sites, 0);
 
     // Iterate over records
     int ix = 0;
     while(vcf_read(fp, hdr, rec) == 0) {
+        // Store missingness for this record
+        int n_samples_missing_data = 0;
         
         // Extract allelic depths
         int sz = 0;
         int* vals = NULL;
         if (bcf_get_format_int32(hdr, rec, "AD", &vals, &sz) > 0) {
-            if (sz != 2*n_samples) {
+
+            int N = 2 * n_samples;
+            if (sz != N) {
                 throw std::invalid_argument("Error in estimating PLAF from allelic depths. All sites must be bi-allelic.");
             }
 
-            // Store total depth, and alternative depth
-            for (int j = 0; j < n_samples; ++j) {
+            for (int j = 0; j < N; ++j) {
+                
+                // Check for missing data
+                if (vals[j] == bcf_int32_missing) {
+                    n_samples_missing_data += 1;
+                    continue;
+                }
+                if (vals[j] == bcf_int32_vector_end) {
+                    continue;
+                }
+
+                // Accumulate
                 total_depth(ix) += vals[j];
                 if (j % 2 == 1) {
                     total_alts(ix) += vals[j];
                 }
+            }
+
+            if (n_samples - n_samples_missing_data < 10) {
+                cout << "WARNING: Less than 10 samples have data for site " << ix << " in VCF." << endl;
             }
 
         } else {

--- a/src/vcf.hpp
+++ b/src/vcf.hpp
@@ -8,7 +8,7 @@ using namespace std;
 
 /*
 * Count the number of loci / variants in the VCF file at `vcf_path`
-* Here, equivalent to number of rows
+*
 */
 int count_sites_in_vcf(const string& vcf_path);
 


### PR DESCRIPTION
In this branch we have made three major changes:
- corrected a bug in PLAF calculation
- handling of missing data within VCFs
- movement of WSAF out of *.cpp, computing as part of unravel library

We also introduce some basic checks after data parsing, ensuring that all elements of the key arrays have been updated.

Missing data is handled by setting values within the Betabinomial lookup array to 1.0. As a result, sites with missing data will have no emission probability; they will only contribute a transition probability to the final likelihood.